### PR TITLE
Use less space in the code

### DIFF
--- a/eduu/plugins/custom_filters.py
+++ b/eduu/plugins/custom_filters.py
@@ -40,9 +40,13 @@ async def save_filter(c: Client, m: Message, s: Strings):
         await m.reply_text(s("filters_add_empty"), quote=True)
         return
 
-    if m.reply_to_message.media and m.reply_to_message.media.value in (
-        "photo", "document", "video", "audio", "animation"
-    ):
+    if m.reply_to_message.media and m.reply_to_message.media.value in {
+        "photo",
+        "document",
+        "video",
+        "audio",
+        "animation",
+    }:
         file_id = getattr(m.reply_to_message, m.reply_to_message.media.value).file_id
         raw_data = (
             m.reply_to_message.caption.markdown if m.reply_to_message.caption is not None else None
@@ -123,7 +127,7 @@ async def serve_filter(c: Client, m: Message):
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
             )
-        elif filter_[4] in ("photo", "document", "video", "audio", "animation", "sticker"):
+        elif filter_[4] in {"photo", "document", "video", "audio", "animation", "sticker"}:
             await targeted_message.reply_cached_media(
                 filter_[3],
                 quote=True,

--- a/eduu/plugins/custom_filters.py
+++ b/eduu/plugins/custom_filters.py
@@ -124,7 +124,7 @@ async def serve_filter(c: Client, m: Message):
                 reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
             )
         elif filter_[4] in ("photo", "document", "video", "audio", "animation", "sticker"):
-            await m.reply_cached_media(
+            await targeted_message.reply_cached_media(
                 filter_[3],
                 quote=True,
                 caption=data,

--- a/eduu/plugins/custom_filters.py
+++ b/eduu/plugins/custom_filters.py
@@ -45,7 +45,7 @@ async def save_filter(c: Client, m: Message, s: Strings):
     ):
         file_id = getattr(m.reply_to_message, m.reply_to_message.media.value).file_id
         raw_data = (
-            m.reply_to_message.caption.html if m.reply_to_message.caption is not None else None
+            m.reply_to_message.caption.markdown if m.reply_to_message.caption is not None else None
         )
         filter_type = m.reply_to_message.media.value
     elif m.reply_to_message and m.reply_to_message.sticker:

--- a/eduu/plugins/custom_filters.py
+++ b/eduu/plugins/custom_filters.py
@@ -40,36 +40,14 @@ async def save_filter(c: Client, m: Message, s: Strings):
         await m.reply_text(s("filters_add_empty"), quote=True)
         return
 
-    if m.reply_to_message and m.reply_to_message.photo:
-        file_id = m.reply_to_message.photo.file_id
+    if m.reply_to_message.media and m.reply_to_message.media.value in (
+        "photo", "document", "video", "audio", "animation"
+    ):
+        file_id = getattr(m.reply_to_message, m.reply_to_message.media.value).file_id
         raw_data = (
-            m.reply_to_message.caption.markdown if m.reply_to_message.caption is not None else None
+            m.reply_to_message.caption.html if m.reply_to_message.caption is not None else None
         )
-        filter_type = "photo"
-    elif m.reply_to_message and m.reply_to_message.document:
-        file_id = m.reply_to_message.document.file_id
-        raw_data = (
-            m.reply_to_message.caption.markdown if m.reply_to_message.caption is not None else None
-        )
-        filter_type = "document"
-    elif m.reply_to_message and m.reply_to_message.video:
-        file_id = m.reply_to_message.video.file_id
-        raw_data = (
-            m.reply_to_message.caption.markdown if m.reply_to_message.caption is not None else None
-        )
-        filter_type = "video"
-    elif m.reply_to_message and m.reply_to_message.audio:
-        file_id = m.reply_to_message.audio.file_id
-        raw_data = (
-            m.reply_to_message.caption.markdown if m.reply_to_message.caption is not None else None
-        )
-        filter_type = "audio"
-    elif m.reply_to_message and m.reply_to_message.animation:
-        file_id = m.reply_to_message.animation.file_id
-        raw_data = (
-            m.reply_to_message.caption.markdown if m.reply_to_message.caption is not None else None
-        )
-        filter_type = "animation"
+        filter_type = m.reply_to_message.media.value
     elif m.reply_to_message and m.reply_to_message.sticker:
         file_id = m.reply_to_message.sticker.file_id
         raw_data = split_text[1] if len(split_text) > 1 else None
@@ -145,55 +123,12 @@ async def serve_filter(c: Client, m: Message):
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
             )
-        elif filter_[4] == "photo":
-            await targeted_message.reply_photo(
+        elif filter_[4] in ("photo", "document", "video", "audio", "animation", "sticker"):
+            await m.reply_cached_media(
                 filter_[3],
                 quote=True,
                 caption=data,
                 parse_mode=ParseMode.MARKDOWN,
-                reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
-            )
-
-        elif filter_[4] == "document":
-            await targeted_message.reply_document(
-                filter_[3],
-                quote=True,
-                caption=data,
-                parse_mode=ParseMode.MARKDOWN,
-                reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
-            )
-
-        elif filter_[4] == "video":
-            await targeted_message.reply_video(
-                filter_[3],
-                quote=True,
-                caption=data,
-                parse_mode=ParseMode.MARKDOWN,
-                reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
-            )
-
-        elif filter_[4] == "audio":
-            await targeted_message.reply_audio(
-                filter_[3],
-                quote=True,
-                caption=data,
-                parse_mode=ParseMode.MARKDOWN,
-                reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
-            )
-
-        elif filter_[4] == "animation":
-            await targeted_message.reply_animation(
-                filter_[3],
-                quote=True,
-                caption=data,
-                parse_mode=ParseMode.MARKDOWN,
-                reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
-            )
-
-        elif filter_[4] == "sticker":
-            await targeted_message.reply_sticker(
-                filter_[3],
-                quote=True,
                 reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
             )
 

--- a/eduu/plugins/notes.py
+++ b/eduu/plugins/notes.py
@@ -40,7 +40,7 @@ async def save_note(c: Client, m: Message, s: Strings):
     ):
         file_id = getattr(m.reply_to_message, m.reply_to_message.media.value).file_id
         raw_data = (
-            m.reply_to_message.caption.html if m.reply_to_message.caption is not None else None
+            m.reply_to_message.caption.markdown if m.reply_to_message.caption is not None else None
         )
         note_type = m.reply_to_message.media.value
     elif m.reply_to_message and m.reply_to_message.sticker:

--- a/eduu/plugins/notes.py
+++ b/eduu/plugins/notes.py
@@ -35,9 +35,13 @@ async def save_note(c: Client, m: Message, s: Strings):
         await m.reply_text(s("notes_add_empty"), quote=True)
         return
 
-    if m.reply_to_message.media and m.reply_to_message.media.value in (
-        "photo", "document", "video", "audio", "animation"
-    ):
+    if m.reply_to_message.media and m.reply_to_message.media.value in {
+        "photo",
+        "document",
+        "video",
+        "audio",
+        "animation",
+    }:
         file_id = getattr(m.reply_to_message, m.reply_to_message.media.value).file_id
         raw_data = (
             m.reply_to_message.caption.markdown if m.reply_to_message.caption is not None else None
@@ -111,7 +115,7 @@ async def serve_note(c: Client, m: Message, txt):
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
             )
-        elif note[4] in ("photo", "document", "video", "audio", "animation", "sticker"):
+        elif note[4] in {"photo", "document", "video", "audio", "animation", "sticker"}:
             await m.reply_cached_media(
                 note[3],
                 quote=True,
@@ -119,6 +123,7 @@ async def serve_note(c: Client, m: Message, txt):
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
             )
+
 
 @Client.on_message(
     (filters.group | filters.private)

--- a/eduu/plugins/notes.py
+++ b/eduu/plugins/notes.py
@@ -35,36 +35,14 @@ async def save_note(c: Client, m: Message, s: Strings):
         await m.reply_text(s("notes_add_empty"), quote=True)
         return
 
-    if m.reply_to_message and m.reply_to_message.photo:
-        file_id = m.reply_to_message.photo.file_id
+    if m.reply_to_message.media and m.reply_to_message.media.value in (
+        "photo", "document", "video", "audio", "animation"
+    ):
+        file_id = getattr(m.reply_to_message, m.reply_to_message.media.value).file_id
         raw_data = (
             m.reply_to_message.caption.html if m.reply_to_message.caption is not None else None
         )
-        note_type = "photo"
-    elif m.reply_to_message and m.reply_to_message.document:
-        file_id = m.reply_to_message.document.file_id
-        raw_data = (
-            m.reply_to_message.caption.html if m.reply_to_message.caption is not None else None
-        )
-        note_type = "document"
-    elif m.reply_to_message and m.reply_to_message.video:
-        file_id = m.reply_to_message.video.file_id
-        raw_data = (
-            m.reply_to_message.caption.html if m.reply_to_message.caption is not None else None
-        )
-        note_type = "video"
-    elif m.reply_to_message and m.reply_to_message.audio:
-        file_id = m.reply_to_message.audio.file_id
-        raw_data = (
-            m.reply_to_message.caption.html if m.reply_to_message.caption is not None else None
-        )
-        note_type = "audio"
-    elif m.reply_to_message and m.reply_to_message.animation:
-        file_id = m.reply_to_message.animation.file_id
-        raw_data = (
-            m.reply_to_message.caption.html if m.reply_to_message.caption is not None else None
-        )
-        note_type = "animation"
+        note_type = m.reply_to_message.media.value
     elif m.reply_to_message and m.reply_to_message.sticker:
         file_id = m.reply_to_message.sticker.file_id
         raw_data = split_text[1] if len(split_text) > 1 else None
@@ -133,58 +111,14 @@ async def serve_note(c: Client, m: Message, txt):
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
             )
-        elif note[4] == "photo":
-            await m.reply_photo(
+        elif note[4] in ("photo", "document", "video", "audio", "animation", "sticker"):
+            await m.reply_cached_media(
                 note[3],
                 quote=True,
                 caption=data,
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
             )
-
-        elif note[4] == "document":
-            await m.reply_document(
-                note[3],
-                quote=True,
-                caption=data,
-                parse_mode=ParseMode.MARKDOWN,
-                reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
-            )
-
-        elif note[4] == "video":
-            await m.reply_video(
-                note[3],
-                quote=True,
-                caption=data,
-                parse_mode=ParseMode.MARKDOWN,
-                reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
-            )
-
-        elif note[4] == "audio":
-            await m.reply_audio(
-                note[3],
-                quote=True,
-                caption=data,
-                parse_mode=ParseMode.MARKDOWN,
-                reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
-            )
-
-        elif note[4] == "animation":
-            await m.reply_animation(
-                note[3],
-                quote=True,
-                caption=data,
-                parse_mode=ParseMode.MARKDOWN,
-                reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
-            )
-
-        elif note[4] == "sticker":
-            await m.reply_sticker(
-                note[3],
-                quote=True,
-                reply_markup=InlineKeyboardMarkup(button) if len(button) != 0 else None,
-            )
-
 
 @Client.on_message(
     (filters.group | filters.private)


### PR DESCRIPTION
Using less space in `notes.py/filters.py` by using `Message.reply_cached_media` ( it's automatically detected the media type from it's file_id ), and using `Message.media.value` to detect the media type when add new `note/filter` instead of add a condition for each media type.

### Note: 
I know that the code style should be in "black" style, but you did not specify the code format, i suggest to add it to workflows.