### PR TITLE
Fix KeyError in YouTube search by correcting JSON response parsing

### DIFF
--- a/eduu/plugins/youtube.py
+++ b/eduu/plugins/youtube.py
@@ -45,7 +45,7 @@ async def search_yt(query):
         )
     ).json()
     list_videos = []
-    for video in page[1]["response"]["contents"]["twoColumnSearchResultsRenderer"][
+    for video in page["response"]["contents"]["twoColumnSearchResultsRenderer"][
         "primaryContents"
     ]["sectionListRenderer"]["contents"][0]["itemSectionRenderer"]["contents"]:
         if video.get("videoRenderer"):


### PR DESCRIPTION
Resolved a KeyError: 1 issue in the search_yt function that occurred when attempting to access page[1] in the JSON response from YouTube's search API. The original code assumed the response was a list or dict with a top-level key '1', but the actual structure starts directly with a 'response' key. Updated the code to remove the unnecessary [1] index and correctly navigate the nested structure starting from page["response"]["contents"]. This ensures the video list is parsed accurately from the API response. Tested with the query "Channa mere ya" and confirmed the fix works as expected.

## Summary by Sourcery

Bug Fixes:
- Fix KeyError: 1 issue in the search_yt function.